### PR TITLE
Use <del> tag for the STRIKETHROUGH inline style

### DIFF
--- a/src/utils/draftRawToHtml.js
+++ b/src/utils/draftRawToHtml.js
@@ -16,6 +16,7 @@ let inlineTagMap = {
   'ITALIC': ['<em>','</em>'],
   'UNDERLINE': ['<u>','</u>'],
   'CODE': ['<code>','</code>'],
+  'STRIKETHROUGH': ['<del>', '</del>'],
   'default': ['<span>','</span>']
 };
 


### PR DESCRIPTION
It was blowing up for me because it didn't have a tag defined for strikethrough. It could be argued that `<del>` has more semantic meaning than strikethrough in a rich text context, but I don't think it matters.
