### PR TITLE
prod build :

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ coverage
 *bundle.js.map
 log.txt
 .idea
+dist

--- a/.npmignore
+++ b/.npmignore
@@ -9,3 +9,4 @@ coverage
 log.txt
 .idea
 example-dist
+src

--- a/README.md
+++ b/README.md
@@ -13,17 +13,25 @@ Inline tags: `<strong> <em> <u> <code> <del>`
 
 ### Install & Usage
 
-Currently this package is provided as a ES6 module only, just require from an ES6 module aware environment like Babel-compiled code.
+`$ npm install draft-js-basic-html-editor`
 
-    $ npm install draft-js-basic-html-editor
+```js
 
-If you're using Webpack, you're probably excluding `node_modules` from your Babel loader, just add an exception
+import BasicHtmlEditor from 'draft-js-basic-html-editor';
 
-    {
-      test: /node_modules\/draft-js-basic-html-editor\//,
-      loaders: ["babel-loader"]
-    }
+const MyEditor = () => {
+  const initialHtml = 'hello, <b>World</b>';
+  const onChange = html => console.log('updated', html);
 
+  return (
+    <BasicHtmlEditor
+      value={ initialHtml }
+      onChange={ onChange }
+      debounce={ 500 }
+    />
+  )
+}
+```
 
 ### Demo
 
@@ -36,10 +44,10 @@ http://dburrows.github.io/draft-js-basic-html-editor/example-dist/
 
 #### To Do
 
-* Block support ✔️ 
+* Block support ✔️
 * Inline tag support ✔️
 * Handle Lists with more than one element ✔️
 * Tests ✔️
 * Links ✔️
 * Images
-* Prod build
+* Prod build ✔️

--- a/package.json
+++ b/package.json
@@ -12,21 +12,26 @@
     "type": "git",
     "url": "https://github.com/dburrows/draft-js-basic-html-editor.git"
   },
-  "main": "src/BasicHtmlEditor.js",
+  "main": "dist/index.js",
   "scripts": {
     "dist-example": "webpack --config webpack.example-dist.config.js",
+    "dist": "webpack --config webpack.dist.config.js -p",
     "test-watch": "mocha --recursive --compilers js:babel-register -r babel-polyfill -w tests/",
-    "release": "release-it"
+    "release": "npm run dist && release-it"
   },
   "author": "David Burrows <david@designsuperbuild.com>",
   "license": "MIT",
   "dependencies": {
-    "draft-js": "^0.5.0",
-    "lodash": "^4.6.1",
-    "react": "^0.14.7",
-    "react-dom": "^0.14.7"
+    "draft-js": "^0.9.1",
+    "lodash": "^4.6.1"
+  },
+  "peerDependencies": {
+    "react": "^15",
+    "react-dom": "^15"
   },
   "devDependencies": {
+    "react": "^15",
+    "react-dom": "^15",
     "babel-core": "^6.8.0",
     "babel-eslint": "^6.0.4",
     "babel-loader": "^6.2.4",

--- a/webpack.dist.config.js
+++ b/webpack.dist.config.js
@@ -1,0 +1,32 @@
+var webpack = require("webpack");
+var path = require('path');
+
+module.exports = {
+  devtool: false,
+  entry: {
+    example: [
+      "./src/BasicHtmlEditor.js"
+    ]
+  },
+  output: {
+    path: './dist',
+    filename: "index.js"
+  },
+  externals: ['react', 'react-dom'],
+  module: {
+    loaders: [
+      {
+        test: /\.css$/, loader: "style-loader!css-loader"
+      },
+      {
+        test: /\.scss$/,
+        loader: "style!css!postcss!sass"
+      },
+      {
+        test: /\.js$/,
+        exclude: [ /node_modules/],
+        loaders: ["babel-loader"]
+      }
+    ]
+  }
+};


### PR DESCRIPTION
Hi!

This produce an ES5 build so we dont have to tweak webpack

 - add `npm run dist` task and call it on `npm run release`
 - use webpack.dist.config.js to build to /dist/index.js without react/react-dom
 - use dist/index.js by default in package.json
 - update readme
 - update draft.js version

draft.js is still bundled, maybe it should be a peerDependency too ?